### PR TITLE
Add delete all to report api

### DIFF
--- a/src/main/java/nl/nn/testtool/web/api/ReportApi.java
+++ b/src/main/java/nl/nn/testtool/web/api/ReportApi.java
@@ -235,6 +235,23 @@ public class ReportApi extends ApiBase {
 		return Response.ok().build();
 	}
 
+	@DELETE
+	@Path("/{storage}/")
+	public Response deleteAllReports(@PathParam("storage") String storageName) {
+		Storage storage = testTool.getStorage(storageName);
+		List<String> errorMessages = new ArrayList<>();
+		try {
+			storage.clear();
+		} catch(StorageException e) {
+			errorMessages.add(String.format("Could not clear storage [%s], reason: %s", storage.getName(), e.getMessage());
+			log.error("Failed to clear storage [{}]", storage.getName(), e);
+		}
+		if (!errorMessages.isEmpty()) {
+			return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(errorMessages).build();
+		}
+		return Response.ok().build();
+	}
+
 	/**
 	 * Get the n latest reports in the storage.
 	 *

--- a/src/main/java/nl/nn/testtool/web/api/ReportApi.java
+++ b/src/main/java/nl/nn/testtool/web/api/ReportApi.java
@@ -243,7 +243,7 @@ public class ReportApi extends ApiBase {
 		try {
 			storage.clear();
 		} catch(StorageException e) {
-			errorMessages.add(String.format("Could not clear storage [%s], reason: %s", storage.getName(), e.getMessage());
+			errorMessages.add(String.format("Could not clear storage [%s], reason: %s", storage.getName(), e.getMessage()));
 			log.error("Failed to clear storage [{}]", storage.getName(), e);
 		}
 		if (!errorMessages.isEmpty()) {

--- a/src/main/java/nl/nn/testtool/web/api/ReportApi.java
+++ b/src/main/java/nl/nn/testtool/web/api/ReportApi.java
@@ -236,7 +236,7 @@ public class ReportApi extends ApiBase {
 	}
 
 	@DELETE
-	@Path("/{storage}/")
+	@Path("/all/{storage}/")
 	public Response deleteAllReports(@PathParam("storage") String storageName) {
 		Storage storage = testTool.getStorage(storageName);
 		List<String> errorMessages = new ArrayList<>();


### PR DESCRIPTION
I tried to have the same URL path as we have for deleting specific reports, with query parameters omitted for deleting all reports. That way, you delete all reports when you intend to delete a specific report. I fixed that by introducing path component `all` for the path to delete all reports.