### PR TITLE
Added field in TestTool for the reports in progress threshold time and an API get request for this field.

### DIFF
--- a/src/main/java/nl/nn/testtool/TestTool.java
+++ b/src/main/java/nl/nn/testtool/TestTool.java
@@ -93,6 +93,7 @@ public class TestTool {
 	private @Getter boolean closeNewThreadsOnly = false;
 	private @Getter boolean closeMessageCapturers = false;
 	private @Setter @Getter @Inject @Autowired Views views;
+	private @Setter @Getter int reportsInProgressThreshold = 300000;
 	boolean devMode = false; // See testConcurrentLastEndpointAndFirstStartpointForSameCorrelationId()
 
 	@PostConstruct

--- a/src/main/java/nl/nn/testtool/web/api/TestToolApi.java
+++ b/src/main/java/nl/nn/testtool/web/api/TestToolApi.java
@@ -168,6 +168,18 @@ public class TestToolApi extends ApiBase {
 		}
 	}
 
+    /**
+     * Gets the report in progress warning threshold time
+     *
+     * @return Response containing the time it will take before ladybug shows a warning that a report is still in progress
+     * */
+    @GET
+    @Path("/in-progress/threshold-time")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getReportsInProgressWarningThreshold(){
+        return Response.ok(testTool.getReportsInProgressThreshold()).build();
+    }
+
 	/**
 	 * Change the default transformation.
 	 *


### PR DESCRIPTION
in TestTool.java:
added a field to store the time it takes before ladybug-frontend should show a warning about a report being in progress for too long. (in milliseconds)

in TestToolApi.java:
get request for reports in progress threshold time field from TestTool

This is added for issue "Show reports in progress warning #361" in the ladybug-frontend project