### PR TITLE
Changed metadataApi class so it accepts multiple filters now

### DIFF
--- a/src/main/java/nl/nn/testtool/web/api/MetadataApi.java
+++ b/src/main/java/nl/nn/testtool/web/api/MetadataApi.java
@@ -70,12 +70,15 @@ public class MetadataApi extends ApiBase {
 
 		List<String> searchValues = new ArrayList<>();
 		for(String field : metadataNames) {
+			boolean changed = false;
 			for (int filterHeaderIndex = 0; filterHeaderIndex < filterHeaders.size(); filterHeaderIndex++) {
 				if (filterHeaders.get(filterHeaderIndex).equals(field)) {
 					searchValues.add(filterParams.get(filterHeaderIndex));
-				} else {
-					searchValues.add(null);
+					changed = true;
 				}
+			}
+			if(!changed) {
+				searchValues.add(null);
 			}
 		}
 		try {

--- a/src/main/java/nl/nn/testtool/web/api/MetadataApi.java
+++ b/src/main/java/nl/nn/testtool/web/api/MetadataApi.java
@@ -70,9 +70,9 @@ public class MetadataApi extends ApiBase {
 		List<String> searchValues = new ArrayList<>();
 		for(String field : metadataNames) {
 			boolean changed = false;
-			for (int filterHeaderIndex = 0; filterHeaderIndex < filterHeaders.size(); filterHeaderIndex++) {
-				if (filterHeaders.get(filterHeaderIndex).equals(field)) {
-					searchValues.add(filterParams.get(filterHeaderIndex));
+			for (String filterHeader : filterHeaders) {
+				if (filterHeader.equals(field)) {
+					searchValues.add(filterParams.get(filterHeaders.indexOf(filterHeader)));
 					changed = true;
 				}
 			}

--- a/src/main/java/nl/nn/testtool/web/api/MetadataApi.java
+++ b/src/main/java/nl/nn/testtool/web/api/MetadataApi.java
@@ -70,9 +70,9 @@ public class MetadataApi extends ApiBase {
 		List<String> searchValues = new ArrayList<>();
 		for(String field : metadataNames) {
 			boolean changed = false;
-			for (String filterHeader : filterHeaders) {
-				if (filterHeader.equals(field)) {
-					searchValues.add(filterParams.get(filterHeaders.indexOf(filterHeader)));
+			for (int filterHeaderIndex = 0; filterHeaderIndex < filterHeaders.size(); filterHeaderIndex++) {
+				if (filterHeaders.get(filterHeaderIndex).equals(field)) {
+					searchValues.add(filterParams.get(filterHeaderIndex));
 					changed = true;
 				}
 			}
@@ -101,7 +101,7 @@ public class MetadataApi extends ApiBase {
 
 			return Response.ok().entity(metadata).build();
 		} catch (Exception e) {
-			return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("Could not find metadata with limit [" + limit + "] and filter [" + filterParams + "] - detailed error message - " + e + Arrays.toString(e.getStackTrace())).build();
+			return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("Could not find metadata with limit " + limit + " and filter [" + filterParams + "] - detailed error message - " + e + Arrays.toString(e.getStackTrace())).build();
 		}
 	}
 

--- a/src/main/java/nl/nn/testtool/web/api/MetadataApi.java
+++ b/src/main/java/nl/nn/testtool/web/api/MetadataApi.java
@@ -52,9 +52,9 @@ public class MetadataApi extends ApiBase {
 	 * @param storageName Name of the storage to search.
 	 * @param metadataNames The metadata names to return.
 	 * @param limit Maximum number of results to return.
-	 * @param filterHeader The header on which we filter.
+	 * @param filterHeaders The header on which we filter.
 	 * @param uriInfo Query parameters for search.
-	 * @param filterParam The regex on which the report names will be filtered
+	 * @param filterParams The regex on which the report names will be filtered
 	 * @return Response containing fields [List[String]] and values [List[List[Object]]].
 	 * @throws ApiException If an exception occurs during metadata search in storage.
 	 */
@@ -64,16 +64,18 @@ public class MetadataApi extends ApiBase {
 	public Response getMetadataList(@PathParam("storage") String storageName,
 									@QueryParam("metadataNames") List<String> metadataNames,
 									@DefaultValue("-1") @QueryParam("limit") int limit,
-									@DefaultValue("") @QueryParam("filterHeader") String filterHeader,
-									@DefaultValue("(.*)") @QueryParam("filter") String filterParam ,
+									@DefaultValue("") @QueryParam("filterHeader") List<String> filterHeaders,
+									@DefaultValue("(.*)") @QueryParam("filter") List<String> filterParams ,
 									@Context UriInfo uriInfo) {
 
 		List<String> searchValues = new ArrayList<>();
 		for(String field : metadataNames) {
-			if (filterHeader.equals(field)) {
-				searchValues.add(filterParam);
-			} else {
-				searchValues.add(null);
+			for (int filterHeaderIndex = 0; filterHeaderIndex < filterHeaders.size(); filterHeaderIndex++) {
+				if (filterHeaders.get(filterHeaderIndex).equals(field)) {
+					searchValues.add(filterParams.get(filterHeaderIndex));
+				} else {
+					searchValues.add(null);
+				}
 			}
 		}
 		try {
@@ -97,7 +99,7 @@ public class MetadataApi extends ApiBase {
 
 			return Response.ok().entity(metadata).build();
 		} catch (Exception e) {
-			return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("Could not find metadata with limit [" + limit + "] and filter [" + filterParam + "] - detailed error message - " + e + Arrays.toString(e.getStackTrace())).build();
+			return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("Could not find metadata with limit [" + limit + "] and filter [" + filterParams + "] - detailed error message - " + e + Arrays.toString(e.getStackTrace())).build();
 		}
 	}
 

--- a/src/main/java/nl/nn/testtool/web/api/MetadataApi.java
+++ b/src/main/java/nl/nn/testtool/web/api/MetadataApi.java
@@ -64,10 +64,9 @@ public class MetadataApi extends ApiBase {
 	public Response getMetadataList(@PathParam("storage") String storageName,
 									@QueryParam("metadataNames") List<String> metadataNames,
 									@DefaultValue("-1") @QueryParam("limit") int limit,
-									@DefaultValue("") @QueryParam("filterHeader") List<String> filterHeaders,
-									@DefaultValue("(.*)") @QueryParam("filter") List<String> filterParams ,
+									@QueryParam("filterHeader") List<String> filterHeaders,
+									@QueryParam("filter") List<String> filterParams ,
 									@Context UriInfo uriInfo) {
-
 		List<String> searchValues = new ArrayList<>();
 		for(String field : metadataNames) {
 			boolean changed = false;

--- a/src/main/java/nl/nn/testtool/web/api/MetadataApi.java
+++ b/src/main/java/nl/nn/testtool/web/api/MetadataApi.java
@@ -52,7 +52,7 @@ public class MetadataApi extends ApiBase {
 	 * @param storageName Name of the storage to search.
 	 * @param metadataNames The metadata names to return.
 	 * @param limit Maximum number of results to return.
-	 * @param filterHeaders The header on which we filter.
+	 * @param filterHeaders The headers on which we filter.
 	 * @param uriInfo Query parameters for search.
 	 * @param filterParams The regex on which the report names will be filtered
 	 * @return Response containing fields [List[String]] and values [List[List[Object]]].


### PR DESCRIPTION
Needed for issue [290](https://github.com/wearefrank/ladybug-frontend/issues/290) of the ladybug frontend project.

Functionality for multiple filters was already present, but not correctly implemented as it would only accept one filter parameter from the getMetadataList GET request. Resulting in only the first filter to be sent to the api to work and all others would be ignored.