### PR TITLE
fix: copyright needed to be updated to 2024

### DIFF
--- a/src/main/java/nl/nn/testtool/web/api/MetadataApi.java
+++ b/src/main/java/nl/nn/testtool/web/api/MetadataApi.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2021-2023 WeAreFrank!
+   Copyright 2021-2024 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
A small fix for the copyright year. I forgot to update it in the previous pull request.