### PR TITLE
Metadata type definition for the TestToolApi

### DIFF
--- a/src/main/java/nl/nn/testtool/MetadataExtractor.java
+++ b/src/main/java/nl/nn/testtool/MetadataExtractor.java
@@ -278,7 +278,19 @@ public class MetadataExtractor {
 	}
 
 	public boolean isTimestamp(String metadataName) {
-		return metadataName.equals("endTime");
+		return metadataName.equals("endTime") || metadataName.equals("startTime");
 	}
 
+	public String getType(String metadataName) {
+		if(this.isInteger(metadataName)) {
+			return "int";
+		}
+		if (this.isLong(metadataName)) {
+			return "long";
+		}
+		if (this.isTimestamp(metadataName)) {
+			return "timestamp";
+		}
+		return "string";
+	}
 }

--- a/src/main/java/nl/nn/testtool/MetadataExtractor.java
+++ b/src/main/java/nl/nn/testtool/MetadataExtractor.java
@@ -282,7 +282,7 @@ public class MetadataExtractor {
 	}
 
 	public String getType(String metadataName) {
-		if(this.isInteger(metadataName)) {
+		if (this.isInteger(metadataName)) {
 			return "int";
 		}
 		if (this.isLong(metadataName)) {

--- a/src/main/java/nl/nn/testtool/web/api/TestToolApi.java
+++ b/src/main/java/nl/nn/testtool/web/api/TestToolApi.java
@@ -241,6 +241,11 @@ public class TestToolApi extends ApiBase {
 			map.put("metadataLabels", getMetadataLabels(view.getMetadataNames()));
 			map.put("crudStorage", view.getDebugStorage() instanceof CrudStorage);
 			map.put("nodeLinkStrategy", view.getNodeLinkStrategy());
+			Map<String, String> metadataTypes = new HashMap<>();
+			for(String metadataName : view.getMetadataNames()) {
+				metadataTypes.put(metadataName, metadataExtractor.getType(metadataName));
+			}
+			map.put("metadataTypes", metadataTypes);
 			response.put(view.getName(), map);
 		}
 		return Response.ok(response).build();


### PR DESCRIPTION
Needed for issue [#291](https://github.com/wearefrank/ladybug-frontend/issues/291)

Adds an extra field in the testtool/views/ GET request that gives the types of the different fields currently being used by reports.
ex. correlationId: string, storageId:int, etc.