### PR TITLE
fix: storage name in view

### DIFF
--- a/src/main/java/nl/nn/testtool/filter/View.java
+++ b/src/main/java/nl/nn/testtool/filter/View.java
@@ -123,24 +123,6 @@ public class View implements BeanParent {
 		return getName();
 	}
 
-	public Map<String, Object> toMap(boolean isDefaultView, String storageName) {
-		Map<String, String> metadataTypes = new HashMap<>();
-		for (String metadataName : getMetadataNames()) {
-			metadataTypes.put(metadataName, metadataExtractor.getType(metadataName));
-		}
-
-		return new HashMap<String, Object>() {{
-			put("storageName", storageName);
-			put("defaultView", isDefaultView);
-			put("metadataNames", metadataNames);
-			put("metadataLabels", getMetadataLabels());
-			put("crudStorage", debugStorage instanceof CrudStorage);
-			put("nodeLinkStrategy", nodeLinkStrategy);
-			put("name", getName());
-			put("metadataTypes", metadataTypes);
-		}};
-	}
-
 	public List<String> getMetadataLabels() {
 		List<String> metadataLabels = new ArrayList<>();
 		for (String metadataName : getMetadataNames()) {

--- a/src/main/java/nl/nn/testtool/filter/View.java
+++ b/src/main/java/nl/nn/testtool/filter/View.java
@@ -123,14 +123,14 @@ public class View implements BeanParent {
 		return getName();
 	}
 
-	public Map<String, Object> toMap(boolean isDefaultView) {
+	public Map<String, Object> toMap(boolean isDefaultView, String storageName) {
 		Map<String, String> metadataTypes = new HashMap<>();
 		for (String metadataName : getMetadataNames()) {
 			metadataTypes.put(metadataName, metadataExtractor.getType(metadataName));
 		}
 
 		return new HashMap<String, Object>() {{
-			put("storageName", debugStorage.getName());
+			put("storageName", storageName);
 			put("defaultView", isDefaultView);
 			put("metadataNames", metadataNames);
 			put("metadataLabels", getMetadataLabels());

--- a/src/main/java/nl/nn/testtool/web/api/TestToolApi.java
+++ b/src/main/java/nl/nn/testtool/web/api/TestToolApi.java
@@ -233,7 +233,20 @@ public class TestToolApi extends ApiBase {
 		// ExtendedBeanInfo isn't used anymore with newer CXF versions)
 		Map<String, Map<String, Object>> response = new LinkedHashMap<>();
 		for (View view : views) {
-			response.put(view.getName(), view.toMap(view == views.getDefaultView(), view.getDebugStorage().getName()));
+			Map<String, Object> map = new HashMap<>();
+			map.put("name", view.getName());
+			map.put("storageName", view.getDebugStorage().getName());
+			map.put("defaultView", view == views.getDefaultView());
+			map.put("metadataNames", view.getMetadataNames());
+			map.put("metadataLabels", view.getMetadataLabels());
+			map.put("crudStorage", view.getDebugStorage() instanceof CrudStorage);
+			map.put("nodeLinkStrategy", view.getNodeLinkStrategy());
+			Map<String, String> metadataTypes = new HashMap<>();
+			for (String metadataName : view.getMetadataNames()) {
+				metadataTypes.put(metadataName, metadataExtractor.getType(metadataName));
+			}
+			map.put("metadataTypes", metadataTypes);
+			response.put(view.getName(), map);
 		}
 		return Response.ok(response).build();
 	}

--- a/src/main/java/nl/nn/testtool/web/api/TestToolApi.java
+++ b/src/main/java/nl/nn/testtool/web/api/TestToolApi.java
@@ -233,7 +233,7 @@ public class TestToolApi extends ApiBase {
 		// ExtendedBeanInfo isn't used anymore with newer CXF versions)
 		Map<String, Map<String, Object>> response = new LinkedHashMap<>();
 		for (View view : views) {
-			response.put(view.getName(), view.toMap(view == views.getDefaultView()));
+			response.put(view.getName(), view.toMap(view == views.getDefaultView(), view.getDebugStorage().getName()));
 		}
 		return Response.ok(response).build();
 	}


### PR DESCRIPTION
Reset the getViews endpoint back to how it was because an issue occured where calling `view.getDebugStorage().getName()` resulted in a different value than when calling `debugStorage().getName()` from inside of the view class.