### PR TITLE
Remove EnableTransactionManagement annotation

### DIFF
--- a/src/main/java/nl/nn/testtool/storage/database/DbmsSupport.java
+++ b/src/main/java/nl/nn/testtool/storage/database/DbmsSupport.java
@@ -69,7 +69,7 @@ public class DbmsSupport {
 	}
 
 	public String getRowNumber(String order, String sort) {
-		if ("Oracle".equals(commonDatabaseName) || "Microsoft SQL Server".equals(commonDatabaseName)) {
+		if ("Oracle".equals(commonDatabaseName)) {
 			return "row_number() over (order by "+order+(sort==null?"":" "+sort)+") "+getRowNumberShortName();
 		}
 		return "";

--- a/src/main/resources/ladybug/DatabaseChangelog_Debug.xml
+++ b/src/main/resources/ladybug/DatabaseChangelog_Debug.xml
@@ -3,7 +3,10 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.26.xsd"
 	>
-	<changeSet id="Ladybug:1" author="Jaco de Groot">
+	<property name="BLOB_FIELD_TYPE" value="bytea" dbms="postgresql"/>
+	<property name="BLOB_FIELD_TYPE" value="blob" dbms="!postgresql"/>
+
+	<changeSet id="Ladybug:1" author="Jaco de Groot" failOnError="false">
 		<comment>Add table LADYBUG</comment>
 		<createTable tableName="LADYBUG">
 			<column name="STORAGEID" type="INTEGER" autoIncrement="true">


### PR DESCRIPTION
Remove EnableTransactionManagement annotation.
When using bytea in PostgreSQL you no longer need a transactionmanager.

Removed sql hints when using mssql. These no longer seem to work.

I have changed the Liquibase script, so if people are using this it will break 😢 

The OptionalTransactionManager may be removed after this pr.

Closes https://github.com/frankframework/frankframework/pull/6824 and https://github.com/frankframework/frankframework/pull/6764.