### PR TITLE
Feat: add crud storage boolean to storage and report

### DIFF
--- a/src/main/java/nl/nn/testtool/Report.java
+++ b/src/main/java/nl/nn/testtool/Report.java
@@ -167,6 +167,10 @@ public class Report implements Serializable {
 		return storage;
 	}
 
+	public boolean isCrudStorage() {
+		return this.storage.isCrudStorage();
+	}
+
 	public void setStorageId(Integer storageId) {
 		transientStorageId = storageId;
 	}

--- a/src/main/java/nl/nn/testtool/Report.java
+++ b/src/main/java/nl/nn/testtool/Report.java
@@ -168,7 +168,7 @@ public class Report implements Serializable {
 	}
 
 	public boolean isCrudStorage() {
-		return this.storage.isCrudStorage();
+		return storage.isCrudStorage();
 	}
 
 	public void setStorageId(Integer storageId) {

--- a/src/main/java/nl/nn/testtool/storage/Storage.java
+++ b/src/main/java/nl/nn/testtool/storage/Storage.java
@@ -35,6 +35,10 @@ public interface Storage {
 
 	public List getStorageIds() throws StorageException;
 
+	default boolean isCrudStorage() {
+		return this instanceof CrudStorage;
+	}
+
 	/**
 	 * Get a list of metadata records. A metadata record is also a list and
 	 * contains the metadata for a specific report.

--- a/src/main/java/nl/nn/testtool/storage/Storage.java
+++ b/src/main/java/nl/nn/testtool/storage/Storage.java
@@ -35,10 +35,6 @@ public interface Storage {
 
 	public List getStorageIds() throws StorageException;
 
-	default boolean isCrudStorage() {
-		return this instanceof CrudStorage;
-	}
-
 	/**
 	 * Get a list of metadata records. A metadata record is also a list and
 	 * contains the metadata for a specific report.
@@ -73,4 +69,8 @@ public interface Storage {
 	public List getFilterValues(String column) throws StorageException;
 
 	public String getUserHelp(String column);
+
+	default boolean isCrudStorage() {
+		return this instanceof CrudStorage;
+	}
 }

--- a/src/main/java/nl/nn/testtool/storage/database/DatabaseStorage.java
+++ b/src/main/java/nl/nn/testtool/storage/database/DatabaseStorage.java
@@ -249,7 +249,9 @@ public class DatabaseStorage implements Storage {
 		log.debug("Get report query: " + query);
 		List<Report> result = ladybugJdbcTemplate.query(query, new Object[]{storageId}, new int[] {Types.INTEGER},
 				(resultSet, rowNum) -> getReport(storageId, resultSet.getBytes(1)));
-		return result.get(0);
+		Report report = result.get(0);
+		report.setStorage(this);
+		return report;
 	}
 
 	// StorageException is allowed by Storage.getReport(), hence no need to handle it in the lambda expression that will


### PR DESCRIPTION
Added `isCrudStorage` method to storage interface, which is added to the report so the frontend knows if the report is from a readonly storage.