### PR TITLE
Feat: make variable map available for the frontend

### DIFF
--- a/src/main/java/nl/nn/testtool/MetadataExtractor.java
+++ b/src/main/java/nl/nn/testtool/MetadataExtractor.java
@@ -284,25 +284,17 @@ public class MetadataExtractor {
 	}
 
 	public Object fromStringtoObject(String metadataName, String metadataValue) {
-		if (metadataName.equals("storageId")) {
-			return Integer.valueOf(metadataValue);
-		}
-		if (metadataName.equals("storageSize")) {
-			return Long.valueOf(metadataValue);
-		}
-		if (metadataName.equals("startTime")) {
-			return Long.valueOf(metadataValue);
-		}
-		if (metadataName.equals("endTime")) {
-			return Long.valueOf(metadataValue);
-		}
-		if (metadataName.equals("estimatedMemoryUsage")) {
-			return Long.valueOf(metadataValue);
-		}
-		if (metadataName.equals("numberOfCheckpoints")) {
-			return Integer.valueOf(metadataValue);
-		}
-		return metadataValue;
+        switch (metadataName) {
+            case "storageId":
+            case "numberOfCheckpoints":
+                return Integer.valueOf(metadataValue);
+            case "storageSize":
+            case "startTime":
+            case "endTime":
+            case "estimatedMemoryUsage":
+                return Long.valueOf(metadataValue);
+        }
+        return metadataValue;
 	}
 
 	public Object fromGUIToObject(String metadataName, String metadataValue) {

--- a/src/main/java/nl/nn/testtool/MetadataExtractor.java
+++ b/src/main/java/nl/nn/testtool/MetadataExtractor.java
@@ -237,6 +237,9 @@ public class MetadataExtractor {
 		if (metadataName.equals("variableCsv")) {
 			return report.getVariableCsv();
 		}
+		if (metadataName.equals("variableMap")) {
+			return report.getVariablesAsMap();
+		}
 		for (MetadataFieldExtractor metadataFieldExtractor : metadataFieldExtractors) {
 			if (metadataFieldExtractor.getName().equals(metadataName)) {
 				return metadataFieldExtractor.extractMetadata(report);


### PR DESCRIPTION
Made sure the already existing method `getVariablesAsMap` is available to retrieve in the frontend when the `variableMap` metadataname is provided.
This way transforming the `variableCsv` to a map does not have to been done in the frontend.
Also made a small refactor.