### PR TITLE
Update link in index.jsp that adds test report to database storage

### DIFF
--- a/ladybug-test-webapp/src/main/webapp/index.jsp
+++ b/ladybug-test-webapp/src/main/webapp/index.jsp
@@ -141,6 +141,12 @@
 	if (reportName.equals(createReportAction)) {
 		ComplexReports.fillComplexErrorReport(correlationId, reportName, testTool);
 	}
+	reportNames.add(reportName = "Add report to database storage");
+	if (reportName.equals(createReportAction)) {
+		Report report = new Report();
+		report.setName("Report for database storage");
+		((CrudStorage)testTool.getStorage("databaseStorage")).store(report);
+	}
 	reportNames.add(reportName = "Report with message context");
 	if (reportName.equals(createReportAction)) {
 		testTool.startpoint(correlationId, null, reportName, "Hello World!");

--- a/ladybug-test-webapp/src/main/webapp/index.jsp
+++ b/ladybug-test-webapp/src/main/webapp/index.jsp
@@ -141,10 +141,16 @@
 	if (reportName.equals(createReportAction)) {
 		ComplexReports.fillComplexErrorReport(correlationId, reportName, testTool);
 	}
+	// This is meant to test the database storage.
+	// Do not expect realistic values from it in the debug table.
 	reportNames.add(reportName = "Add report to database storage");
 	if (reportName.equals(createReportAction)) {
 		Report report = new Report();
 		report.setName("Report for database storage");
+		// Do not leave null because ShownReport.validate() should return true.
+		report.setCorrelationId(correlationId);
+		report.setStubStrategy("Some stub strategy");
+		report.setLinkMethod("Some link method");
 		((CrudStorage)testTool.getStorage("databaseStorage")).store(report);
 	}
 	reportNames.add(reportName = "Report with message context");

--- a/ladybug-test-webapp/src/main/webapp/index.jsp
+++ b/ladybug-test-webapp/src/main/webapp/index.jsp
@@ -141,12 +141,6 @@
 	if (reportName.equals(createReportAction)) {
 		ComplexReports.fillComplexErrorReport(correlationId, reportName, testTool);
 	}
-	reportNames.add(reportName = "Add report to database storage");
-	if (reportName.equals(createReportAction)) {
-		Report report = new Report();
-		report.setName("Report for database storage");
-		((CrudStorage)testTool.getStorage("databaseStorage")).store(report);
-	}
 	reportNames.add(reportName = "Report with message context");
 	if (reportName.equals(createReportAction)) {
 		testTool.startpoint(correlationId, null, reportName, "Hello World!");


### PR DESCRIPTION
To test the database storage, run the test webapp with Spring profile `storage.database`. It does not make sense to do `new Report()` and set the `name` property, and to expect then that the report can be stored.