### PR TITLE
Use parameterized SQL for maxStorageDays cleanup (fixes report storage on H2)

### DIFF
--- a/ladybug-common/src/main/java/org/wearefrank/ladybug/storage/database/DatabaseStorage.java
+++ b/ladybug-common/src/main/java/org/wearefrank/ladybug/storage/database/DatabaseStorage.java
@@ -269,9 +269,14 @@ public class DatabaseStorage implements Storage {
 			delete(deleteQuery, maxNrOfReports);
 		}
 		if (getMaxStorageDays() > -1) {
-			String deleteQuery = "delete from " + getTable() + " where " + getEndTimeColum()
-					+ " < now() - interval '" + getMaxStorageDays() + " days'";
-			int nrOfDeletedReports = ladybugJdbcTemplate.update(deleteQuery);
+			// Compute the cutoff in Java and bind it as a JDBC parameter instead of
+			// using "now() - interval 'N days'": interval arithmetic in that form is
+			// PostgreSQL-specific, and other databases reject it (H2 fails with error
+			// 22007 "Cannot parse INTERVAL constant") from inside the report-store
+			// path, which breaks storing reports altogether.
+			Timestamp cutoff = new Timestamp(System.currentTimeMillis() - getMaxStorageDays() * 24L * 60L * 60L * 1000L);
+			String deleteQuery = "delete from " + getTable() + " where " + getEndTimeColum() + " < ?";
+			int nrOfDeletedReports = ladybugJdbcTemplate.update(deleteQuery, cutoff);
 			log.debug("Checked for reports older than " + getMaxStorageDays() + " days: "
 					+ nrOfDeletedReports + " reports deleted.");
 		}


### PR DESCRIPTION
## Problem

`DatabaseStorage`'s day-based pruning builds its cutoff with PostgreSQL-specific interval syntax:

```java
String deleteQuery = "delete from " + getTable() + " where " + getEndTimeColum()
        + " < now() - interval '" + getMaxStorageDays() + " days'";
```

On H2 this fails with:

```
Cannot parse "INTERVAL" constant "100 days"; SQL statement:
delete from LADYBUG where ENDTIME < now() - interval '100 days' [22007-240]
```

Because the cleanup runs inside the report-store path, the exception breaks **storing reports altogether** on any H2-backed deployment — and the Frank!Framework enables this cleanup by default (`ibistesttool.maxStorageDays=100`), so every F!F-on-H2 setup hits it. Observed in production 2026-08-18 on H2 2.4.240.

## Fix

Compute the cutoff timestamp in Java and bind it as a JDBC parameter:

```java
Timestamp cutoff = new Timestamp(System.currentTimeMillis() - getMaxStorageDays() * 24L * 60L * 60L * 1000L);
String deleteQuery = "delete from " + getTable() + " where " + getEndTimeColum() + " < ?";
int nrOfDeletedReports = ladybugJdbcTemplate.update(deleteQuery, cutoff);
```

This is dialect-independent and matches the parameterized style the neighboring `maxStorageSize` cleanup in the same method already uses. No behavior change on PostgreSQL.

Verified against H2 2.4.240 directly: the old literal fails with the exact production error, the parameterized form succeeds. (The SQL-standard form `interval '100' day` would also parse on both H2 and PostgreSQL, but binding a computed timestamp avoids dialect assumptions entirely.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)